### PR TITLE
k2hb stores full db.aa.bb as topic name so we must match this

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
       RECONCILER_FIXED_DELAY_MILLIS: "1000"
       SECRETS_REGION: "eu-west-2"
       SECRETS_METADATA_STORE_PASSWORD_SECRET: "metastore_password"
-      HBASE_TABLE_PATTERN: ([-\w]+)\.([-\w]+)
+      HBASE_TABLE_PATTERN: db\.([-\w]+)\.([-\w]+)
       HBASE_ZOOKEEPER_PARENT: "/hbase"
       HBASE_ZOOKEEPER_PORT: "2181"
       HBASE_ZOOKEEPER_QUORUM: "hbase"
@@ -99,7 +99,7 @@ services:
       RECONCILER_FIXED_DELAY_MILLIS: "1000"
       SECRETS_REGION: "eu-west-2"
       SECRETS_METADATA_STORE_PASSWORD_SECRET: "metastore_password"
-      HBASE_TABLE_PATTERN: ([-\w]+)\.([-\w]+)
+      HBASE_TABLE_PATTERN: db\.([-\w]+)\.([-\w]+)
       HBASE_ZOOKEEPER_PARENT: "/hbase"
       HBASE_ZOOKEEPER_PORT: "2181"
       HBASE_ZOOKEEPER_QUORUM: "hbase"

--- a/src/integration/kotlin/ReconciliationIntegrationKoTest.kt
+++ b/src/integration/kotlin/ReconciliationIntegrationKoTest.kt
@@ -51,7 +51,7 @@ class ReconciliationIntegrationKoTest : StringSpec() {
     private val columnQualifier = "record".toByteArray()
     private val kafkaDb = "claimant-advances"
     private val kafkaCollection = "advanceDetails"
-    private val kafkaTopic = "$kafkaDb.$kafkaCollection"
+    private val kafkaTopic = "db.$kafkaDb.$kafkaCollection"
 
     private fun emptyMetadataStoreTable() {
         metadatastoreConnection().use {

--- a/src/integration/kotlin/ReconciliationIntegrationTest.kt
+++ b/src/integration/kotlin/ReconciliationIntegrationTest.kt
@@ -38,7 +38,7 @@ class ReconciliationIntegrationTest {
     private val columnQualifier = "record".toByteArray()
     private val kafkaDb = "claimant-advances"
     private val kafkaCollection = "advanceDetails"
-    private val kafkaTopic = "$kafkaDb.$kafkaCollection"
+    private val kafkaTopic = "db.$kafkaDb.$kafkaCollection"
 
     @Test
     fun testThatMatchingRecordsAreReconciledAndMismatchesAreNot() {


### PR DESCRIPTION
k2hb stores full `db.aa.bb` as topic name so we must match this in the reconciler