### PR TITLE
Modify reconciler to accept replicaId env var

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,6 +30,7 @@ services:
       HBASE_CLIENT_SCANNER_TIMEOUT_PERIOD_MS: "60000"
       HBASE_PAUSE_MILLISECONDS: "50"
       HBASE_RETRIES": "3"
+      HBASE_REPLICA_ID: "2"
       METADATASTORE_USER: "reconciliationwriter"
       METADATASTORE_PASSWORD_SECRET_NAME: "metastore_password"
       METADATASTORE_DUMMY_PASSWORD: "my-password"
@@ -44,6 +45,7 @@ services:
       RECONCILER_MINIMUM_AGE_SCALE: "15"
       RECONCILER_MINIMUM_AGE_UNIT: "SECOND"
       SPRING_PROFILES_ACTIVE: DUMMY_SECRETS,RECONCILIATION,HBASE
+
 
   trim-reconciled-records:
     image: trim-reconciled-records:latest

--- a/src/integration/kotlin/ReconciliationIntegrationTest.kt
+++ b/src/integration/kotlin/ReconciliationIntegrationTest.kt
@@ -121,6 +121,7 @@ class ReconciliationIntegrationTest : StringSpec() {
                 addFamily(HColumnDescriptor(columnFamily).apply {
                     maxVersions = Int.MAX_VALUE
                     minVersions = 1
+                    regionReplication = 3
                 })
             })
         }

--- a/src/main/kotlin/uk/gov/dwp/dataworks/kafkatohbase/reconciliation/configuration/HBaseConfiguration.kt
+++ b/src/main/kotlin/uk/gov/dwp/dataworks/kafkatohbase/reconciliation/configuration/HBaseConfiguration.kt
@@ -20,7 +20,8 @@ data class HBaseConfiguration(
     var clientScannerTimeoutPeriodMs: String? = "NOT_SET",
     var clientOperationTimeoutMs: String? = "NOT_SET",
     var rpcReadTimeoutMs: String? = "NOT_SET",
-    var retries: String? = "NOT_SET"
+    var retries: String? = "NOT_SET",
+    var replicaId: Int = 0
 ) {
 
     companion object {
@@ -64,6 +65,9 @@ data class HBaseConfiguration(
 
         return connection
     }
+
+    @Bean
+    fun replicaId() = replicaId!!.toInt()
 
     private fun addShutdownHook(connection: Connection) {
         logger.info("Adding HBase shutdown hook")

--- a/src/main/kotlin/uk/gov/dwp/dataworks/kafkatohbase/reconciliation/configuration/HBaseConfiguration.kt
+++ b/src/main/kotlin/uk/gov/dwp/dataworks/kafkatohbase/reconciliation/configuration/HBaseConfiguration.kt
@@ -21,7 +21,7 @@ data class HBaseConfiguration(
     var clientOperationTimeoutMs: String? = "NOT_SET",
     var rpcReadTimeoutMs: String? = "NOT_SET",
     var retries: String? = "NOT_SET",
-    var replicaId: Int = 0
+    var replicaId: String? = "NOT_SET"
 ) {
 
     companion object {
@@ -67,7 +67,7 @@ data class HBaseConfiguration(
     }
 
     @Bean
-    fun replicaId() = replicaId!!.toInt()
+    fun replicaId() = replicaId?.toIntOrNull() ?: -1
 
     private fun addShutdownHook(connection: Connection) {
         logger.info("Adding HBase shutdown hook")

--- a/src/main/kotlin/uk/gov/dwp/dataworks/kafkatohbase/reconciliation/repositories/impl/HBaseRepositoryImpl.kt
+++ b/src/main/kotlin/uk/gov/dwp/dataworks/kafkatohbase/reconciliation/repositories/impl/HBaseRepositoryImpl.kt
@@ -86,7 +86,9 @@ class HBaseRepositoryImpl(
         setTimeStamp(version)
         isCheckExistenceOnly = true
         consistency = Consistency.TIMELINE
-        setReplicaId = replicaId
+        if (replicaId > 0) {
+            setReplicaId(replicaId)
+        }
     }
 
     private fun table(topicName: String) = TableName.valueOf(tableName(topicName))

--- a/src/main/kotlin/uk/gov/dwp/dataworks/kafkatohbase/reconciliation/repositories/impl/HBaseRepositoryImpl.kt
+++ b/src/main/kotlin/uk/gov/dwp/dataworks/kafkatohbase/reconciliation/repositories/impl/HBaseRepositoryImpl.kt
@@ -86,7 +86,7 @@ class HBaseRepositoryImpl(
         setTimeStamp(version)
         isCheckExistenceOnly = true
         consistency = Consistency.TIMELINE
-        if (replicaId => 0) {
+        if (replicaId >= 0) {
             setReplicaId(replicaId)
         }
     }

--- a/src/main/kotlin/uk/gov/dwp/dataworks/kafkatohbase/reconciliation/repositories/impl/HBaseRepositoryImpl.kt
+++ b/src/main/kotlin/uk/gov/dwp/dataworks/kafkatohbase/reconciliation/repositories/impl/HBaseRepositoryImpl.kt
@@ -42,13 +42,17 @@ class HBaseRepositoryImpl(
                     logger.info(
                         "Checked batch of records from metadata store", "size" to "${records.size}",
                         "topic" to topicName,
-                        "found" to "${found.size}", "not_found" to "${notFound.size}"
+                        "found" to "${found.size}", "not_found" to "${notFound.size}",
+                        "replica_id" to "${replicaId}"
                     )
 
                     notFound.asSequence().map { it.first }.forEach {
                         logger.debug(
                             "Record not found",
-                            "topic_name" to topicName, "hbase_id" to it.hbaseId, "timestamp" to "${it.version}"
+                            "topic_name" to topicName,
+                            "hbase_id" to it.hbaseId,
+                            "timestamp" to "${it.version}",
+                            "replica_id" to "${replicaId}"
                         )
                     }
 

--- a/src/main/kotlin/uk/gov/dwp/dataworks/kafkatohbase/reconciliation/repositories/impl/HBaseRepositoryImpl.kt
+++ b/src/main/kotlin/uk/gov/dwp/dataworks/kafkatohbase/reconciliation/repositories/impl/HBaseRepositoryImpl.kt
@@ -86,7 +86,7 @@ class HBaseRepositoryImpl(
         setTimeStamp(version)
         isCheckExistenceOnly = true
         consistency = Consistency.TIMELINE
-        if (replicaId > 0) {
+        if (replicaId => 0) {
             setReplicaId(replicaId)
         }
     }

--- a/src/main/kotlin/uk/gov/dwp/dataworks/kafkatohbase/reconciliation/repositories/impl/HBaseRepositoryImpl.kt
+++ b/src/main/kotlin/uk/gov/dwp/dataworks/kafkatohbase/reconciliation/repositories/impl/HBaseRepositoryImpl.kt
@@ -13,7 +13,11 @@ import uk.gov.dwp.dataworks.logging.DataworksLogger
 
 @Repository
 @Profile("HBASE")
-class HBaseRepositoryImpl(private val connection: Connection, private val tableNameUtil: TableNameUtil) : HBaseRepository {
+class HBaseRepositoryImpl(
+    private val connection: Connection,
+    private val tableNameUtil: TableNameUtil,
+    private val replicaId: Int
+) : HBaseRepository {
 
     override fun recordsInHbase(topicName: String, records: List<UnreconciledRecord>) =
         recordsExistInHBase(topicName, records)
@@ -22,21 +26,30 @@ class HBaseRepositoryImpl(private val connection: Connection, private val tableN
             .map { it.first }
             .toList()
 
-    private fun recordsExistInHBase(topicName: String, records: List<UnreconciledRecord>): List<Pair<UnreconciledRecord, Boolean>> {
+    private fun recordsExistInHBase(
+        topicName: String,
+        records: List<UnreconciledRecord>
+    ): List<Pair<UnreconciledRecord, Boolean>> {
         return if (records.isNotEmpty()) {
             if (tableExists(topicName)) {
                 (connection.getTable(table(topicName))).use { table ->
-                    val results = records.zip(table.existsAll(records.map { get(it.hbaseId, it.version) }).asIterable())
+                    val results = records.zip(table.existsAll(records.map { get(it.hbaseId, it.version, replicaId) })
+                        .asIterable()
+                    )
                     val (found, notFound)
                             = results.partition(Pair<UnreconciledRecord, Boolean>::second)
 
-                    logger.info("Checked batch of records from metadata store","size" to "${records.size}",
+                    logger.info(
+                        "Checked batch of records from metadata store", "size" to "${records.size}",
                         "topic" to topicName,
-                        "found" to "${found.size}", "not_found" to "${notFound.size}")
+                        "found" to "${found.size}", "not_found" to "${notFound.size}"
+                    )
 
                     notFound.asSequence().map { it.first }.forEach {
-                        logger.debug("Record not found",
-                            "topic_name" to topicName, "hbase_id" to it.hbaseId, "timestamp" to "${it.version}")
+                        logger.debug(
+                            "Record not found",
+                            "topic_name" to topicName, "hbase_id" to it.hbaseId, "timestamp" to "${it.version}"
+                        )
                     }
 
                     results
@@ -58,8 +71,7 @@ class HBaseRepositoryImpl(private val connection: Connection, private val tableN
     private fun tableExists(topicName: String): Boolean {
         return if (_mutableMap.containsKey(topicName)) {
             true
-        }
-        else {
+        } else {
             val exists = connection.admin.tableExists(table(topicName))
             if (exists) {
                 _mutableMap[topicName] = true
@@ -70,10 +82,11 @@ class HBaseRepositoryImpl(private val connection: Connection, private val tableN
 
     private var _mutableMap: MutableMap<String, Boolean> = mutableMapOf()
 
-    private fun get(id: String, version: Long) = Get(tableNameUtil.decodePrintable(id)).apply {
+    private fun get(id: String, version: Long, replicaId: Int) = Get(tableNameUtil.decodePrintable(id)).apply {
         setTimeStamp(version)
         isCheckExistenceOnly = true
         consistency = Consistency.TIMELINE
+        setReplicaId = replicaId
     }
 
     private fun table(topicName: String) = TableName.valueOf(tableName(topicName))

--- a/src/test/kotlin/uk/gov/dwp/dataworks/kafkatohbase/reconciliation/repositories/impl/HBaseRepositoryImplTest.kt
+++ b/src/test/kotlin/uk/gov/dwp/dataworks/kafkatohbase/reconciliation/repositories/impl/HBaseRepositoryImplTest.kt
@@ -17,7 +17,7 @@ import uk.gov.dwp.dataworks.kafkatohbase.reconciliation.utils.TableNameUtil
 class HBaseRepositoryImplTest {
 
     @Test
-    fun confirmConnectionToHbaseAndRecordsCanBeRetrievedWithReplica() {
+    fun confirmConnectionToHbaseAndRecordsCanBeRetrievedWithZeroReplicaId() {
         confirmConnectionToHbaseAndRecordsCanBeRetrieved(0,0)
     }
 

--- a/src/test/kotlin/uk/gov/dwp/dataworks/kafkatohbase/reconciliation/repositories/impl/HBaseRepositoryImplTest.kt
+++ b/src/test/kotlin/uk/gov/dwp/dataworks/kafkatohbase/reconciliation/repositories/impl/HBaseRepositoryImplTest.kt
@@ -18,6 +18,11 @@ class HBaseRepositoryImplTest {
 
     @Test
     fun confirmConnectionToHbaseAndRecordsCanBeRetrievedWithReplica() {
+        confirmConnectionToHbaseAndRecordsCanBeRetrieved(0,0)
+    }
+
+    @Test
+    fun confirmConnectionToHbaseAndRecordsCanBeRetrievedWithReplica() {
         confirmConnectionToHbaseAndRecordsCanBeRetrieved(1,1)
     }
 

--- a/src/test/kotlin/uk/gov/dwp/dataworks/kafkatohbase/reconciliation/repositories/impl/HBaseRepositoryImplTest.kt
+++ b/src/test/kotlin/uk/gov/dwp/dataworks/kafkatohbase/reconciliation/repositories/impl/HBaseRepositoryImplTest.kt
@@ -17,7 +17,16 @@ import uk.gov.dwp.dataworks.kafkatohbase.reconciliation.utils.TableNameUtil
 class HBaseRepositoryImplTest {
 
     @Test
-    fun works() {
+    fun confirmConnectionToHbaseAndRecordsCanBeRetrievedWithReplica() {
+        confirmConnectionToHbaseAndRecordsCanBeRetrieved(1,1)
+    }
+
+    @Test
+    fun confirmReplicaIsSetToDefaultGivenNegativeValue() {
+        confirmConnectionToHbaseAndRecordsCanBeRetrieved(-1,-2)
+    }
+
+    fun confirmConnectionToHbaseAndRecordsCanBeRetrieved(replicaIdExpected: Int, replicaIdActual: Int) {
         val topic = "db.database.collection"
         val tableName = "database:collection"
 
@@ -48,12 +57,13 @@ class HBaseRepositoryImplTest {
             }
         }
 
-        val hBaseRepository = HBaseRepositoryImpl(connection, tableNameUtil)
+        val hBaseRepository = HBaseRepositoryImpl(connection, tableNameUtil, replicaIdActual)
         val unreconciled = hBaseRepository.recordsInHbase(topic, unreconciledRecords)
         assertEquals(1, getCaptor.allValues.size)
         getCaptor.firstValue.forEachIndexed { index, get ->
             assertEquals("${index + 1}", String(get.row))
             assertTrue(get.isCheckExistenceOnly)
+            assertEquals(replicaIdExpected, get.replicaId)
         }
 
         assertEquals(50, unreconciled.size)


### PR DESCRIPTION
In order for us to verify if Hbase has the data stored to the storage medium, we must read from a replica. This will confirm if the information is stored on the storage medium and not being returned from the masters memstore.